### PR TITLE
All user-registered signals are reported to the user code

### DIFF
--- a/service/detail/signalhandler.cpp
+++ b/service/detail/signalhandler.cpp
@@ -247,10 +247,15 @@ void SignalHandler::signal(const boost::system::error_code &e, int signo)
         break;
 
     default:
-        // user-registered signal
-        owner_.signal(signo);
         break;
     }
+
+    // notify owner about signal it has registered
+    if (userRegisteredSignals_.count(signo)) {
+        // user-registered signal
+        owner_.signal(signo);
+    }
+
     startSignals();
 }
 
@@ -477,7 +482,10 @@ void SignalHandler::atFork(utility::AtFork::Event event)
 
 void SignalHandler::registerSignal(int signo)
 {
-    ios_.post([this, signo]() { signals_.add(signo); });
+    ios_.post([this, signo]() {
+        signals_.add(signo);
+        userRegisteredSignals_.insert(signo);
+    });
 }
 
 struct ModeParser {

--- a/service/detail/signalhandler.hpp
+++ b/service/detail/signalhandler.hpp
@@ -27,6 +27,7 @@
 #define shared_service_detail_signalhandler_hpp_included_
 
 #include <memory>
+#include <set>
 
 #include <boost/noncopyable.hpp>
 #include <boost/asio.hpp>
@@ -205,6 +206,7 @@ private:
 
     asio::io_service ios_;
     asio::signal_set signals_;
+    std::set<int> userRegisteredSignals_;
     Allocator mem_;
     Terminator terminator_;
     std::atomic_bool &terminated_;


### PR DESCRIPTION
Even signals handled by service itself (e.g. `SIGUSR1` that dumps server statistics).