### PR TITLE
Added pipe notifier helper + fine tuned persona switching 

### DIFF
--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -1,5 +1,5 @@
 # bump version here
-set(service_VERSION 1.10)
+set(service_VERSION 1.11)
 
 set(service_EXTRA_DEPENDS)
 

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -24,6 +24,7 @@ else()
     detail/ctrlclient.hpp detail/ctrlclient.cpp
     netctrlclient.hpp netctrlclient.cpp
     ctrlhandshake.hpp ctrlhandshake.cpp
+    pipenotifier.hpp pipenotifier.cpp
     )
 endif()
 

--- a/service/persona.hpp
+++ b/service/persona.hpp
@@ -46,6 +46,23 @@ struct Persona {
 
 };
 
+enum class PersonaSwitchMode {
+    /** see man setuid/setgid
+     *  one-way switch, cannot go back
+     */
+    setRealId
+    /** see man seteuid/setegid
+     *  can go back to previous user
+     */
+    , setEffectiveId
+
+    /** see man setreuid/setreguid (keeps real ids)
+     * can go back to previous user
+     * sets saved set-user-ID as well -> can be signalled by new persona
+     */
+    , setEffectiveAndSavedId
+};
+
 /** Run call with elevated rights (process has been started with) and switch
  *  back to normal rights.
  */

--- a/service/pipenotifier.cpp
+++ b/service/pipenotifier.cpp
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2022 Melown Technologies SE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *  Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <system_error>
+
+#include <unistd.h>
+
+#include <dbglog/dbglog.hpp>
+
+#include "pipenotifier.hpp"
+
+namespace service {
+
+PipeNotifier::PipeNotifier(utility::Runnable &runnable)
+    : runnable_(runnable), fd_{ -1, -1 }
+{
+    // direct I/O -> writes should send whole packets
+    if (-1 == ::pipe2(fd_, O_DIRECT)) {
+        std::system_error e(errno, std::system_category());
+        LOG(err2) << "Failed to create notifier pipe: <" << e.what() << ">.";
+        throw e;
+    }
+}
+
+PipeNotifier::~PipeNotifier()
+{
+    for (auto fd : fd_) {
+        if (fd >= 0) { ::close(fd); }
+    }
+}
+
+std::string PipeNotifier::master()
+{
+    char buffer[PIPE_BUF];
+    for (;;) {
+        auto r(::read(fd_[0], buffer, sizeof(buffer)));
+        if (-1 == r) {
+            if (EINTR == errno) {
+                if (!runnable_.isRunning()) {
+                    LOGTHROW(err2, std::runtime_error)
+                        << "Interrupted while writing to notification pipe.";
+                }
+                continue;
+            } else {
+                std::system_error e(errno, std::system_category());
+                LOG(err2) << "Error writing to notification pipe: <"
+                          << e.what() << ">.";
+                throw e;
+            }
+        }
+
+        return std::string(buffer, r);
+    }
+}
+
+void PipeNotifier::slave(const std::string &string)
+{
+    if (string.size() > PIPE_BUF) {
+        LOGTHROW(err2, std::runtime_error)
+            << "Notification string too large (" << string.size()
+            << " > PIPE_BUF(" << PIPE_BUF << ").";
+    }
+
+    for (;;) {
+        auto w(::write(fd_[1], string.data(), string.size()));
+        if (-1 == w) {
+            if (EINTR == errno) {
+                if (!runnable_.isRunning()) {
+                    LOGTHROW(err2, std::runtime_error)
+                        << "Interrupted while writing to notification pipe.";
+                }
+                continue;
+            } else {
+                std::system_error e(errno, std::system_category());
+                LOG(err2) << "Error writing to notification pipe: <"
+                          << e.what() << ">.";
+                throw e;
+            }
+        }
+
+        break;
+    }
+}
+
+} // namespace service

--- a/service/pipenotifier.hpp
+++ b/service/pipenotifier.hpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2022 Melown Technologies SE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *  Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * *  Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef service_pipenotifier_hpp_included_
+#define service_pipenotifier_hpp_included_
+
+#include "utility/runnable.hpp"
+
+namespace service {
+
+class PipeNotifier {
+public:
+    PipeNotifier(utility::Runnable &runnable);
+
+    ~PipeNotifier();
+
+    /** Reads a string from the slave.
+     *  TODO: add read timeout
+     *  NB: Must be called in different process than slave(line)
+     */
+    std::string master();
+
+    /** Writes a string to the master.
+     *  NB: Must be called in different process than master()
+     */
+    void slave(const std::string &string);
+
+private:
+    utility::Runnable &runnable_;
+    int fd_[2];
+};
+
+} // namespace service
+
+#endif // service_pipenotifier_hpp_included_

--- a/service/service.hpp
+++ b/service/service.hpp
@@ -119,11 +119,11 @@ protected:
 
     /** Code that will be run under original persona before persona is switched.
      *
-     *  Returns flag whether original persona should be regainable:
-     *      true -> use seteuid/setegid
-     *      false -> use setuid/setgid
+     *  Returns flag whether original persona should be regainable.
      */
-    virtual bool prePersonaSwitch() { return false; }
+    virtual PersonaSwitchMode prePersonaSwitch() {
+        return PersonaSwitchMode::setRealId;
+    }
 
     /** Code that will be run under new persona after persona is switched.
      */


### PR DESCRIPTION
Added pipe notifier,

The function `Service::prePersonaSwitch` now returns how persona should be switched:
 - `PersonaSwitchMode::setRealId`: sets real user/group ids and user -> process cannot regain previous persona back
 - `PersonaSwitchMode::setEffectiveId`: sets effective user/group ids -> process can regain previous persona
 - `PersonaSwitchMode::setEffectiveId`: sets effective user/group ids using `setreuid`/`setregid` tgat also sets saved _set-user-ID_ to the new effective user that unblocks signals delivery from any process running under the same user; to be used only for debugging

NB `Service::prePersonaSwitch` interface is incompatible with previous version and a super project must be updated to match when library is upraded.
