### PR TITLE
Fix and update timestamp and git hash generation.

### DIFF
--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -32,35 +32,28 @@ else()
   endif()
 endif()
 
-
 ### vvv add build date and time vvv
-string(TIMESTAMP build_timestamp "%Y-%m-%d %H:%M:%S")
-configure_file(buildtimestamp.hpp.in buildtimestamp.hpp ESCAPE_QUOTES @ONLY)
+string(TIMESTAMP service_build_timestamp "%Y-%m-%d %H:%M:%S")
+configure_file(buildtimestamp.cpp.in buildtimestamp.cpp ESCAPE_QUOTES @ONLY)
+list(APPEND service_SOURCES buildtimestamp.hpp buildtimestamp.cpp)
 ### ^^^ add build date and time ^^^
 
 ### vvv git hash functionality vvv
-
 if (GIT_FOUND)
   execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
     RESULT_VARIABLE result
-    OUTPUT_VARIABLE git_hash
+    OUTPUT_VARIABLE service_git_hash
     OUTPUT_STRIP_TRAILING_WHITESPACE
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   if (result)
-    set(git_hash "")
+    set(service_git_hash "")
   endif()
 else()
-  set(git_hash "")
+  set(service_git_hash "")
 endif()
 
-set(githash_in githash.hpp.in)
-set(githash_out ${CMAKE_CURRENT_BINARY_DIR}/githash.hpp)
-
-configure_file(${githash_in} ${githash_out}
-  ESCAPE_QUOTES @ONLY)
-
-list(APPEND service_SOURCES ${githash_out})
-
+configure_file(githash.cpp.in githash.cpp ESCAPE_QUOTES @ONLY)
+list(APPEND service_SOURCES githash.hpp githash.cpp)
 ### ^^^ git hash functionality ^^^
 
 

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 
 ### vvv add build date and time vvv
-string(TIMESTAMP BUILD_TIMESTAMP "%Y-%m-%d %H:%M:%S")
+string(TIMESTAMP build_timestamp "%Y-%m-%d %H:%M:%S")
 configure_file(buildtimestamp.hpp.in buildtimestamp.hpp ESCAPE_QUOTES @ONLY)
 ### ^^^ add build date and time ^^^
 

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -34,8 +34,9 @@ endif()
 
 ### vvv add build date and time vvv
 string(TIMESTAMP service_build_timestamp "%Y-%m-%d %H:%M:%S")
-configure_file(buildtimestamp.cpp.in buildtimestamp.cpp ESCAPE_QUOTES @ONLY)
-list(APPEND service_SOURCES buildtimestamp.hpp buildtimestamp.cpp)
+configure_file(buildtimestamp.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/buildtimestamp.cpp 
+  ESCAPE_QUOTES @ONLY)
+list(APPEND service_SOURCES buildtimestamp.hpp ${CMAKE_CURRENT_BINARY_DIR}/buildtimestamp.cpp)
 ### ^^^ add build date and time ^^^
 
 ### vvv git hash functionality vvv
@@ -51,9 +52,9 @@ if (GIT_FOUND)
 else()
   set(service_git_hash "")
 endif()
-
-configure_file(githash.cpp.in githash.cpp ESCAPE_QUOTES @ONLY)
-list(APPEND service_SOURCES githash.hpp githash.cpp)
+configure_file(githash.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/githash.cpp 
+  ESCAPE_QUOTES @ONLY)
+list(APPEND service_SOURCES githash.hpp ${CMAKE_CURRENT_BINARY_DIR}/githash.cpp)
 ### ^^^ git hash functionality ^^^
 
 

--- a/service/buildtimestamp.cpp.in
+++ b/service/buildtimestamp.cpp.in
@@ -1,0 +1,2 @@
+#include "buildtimestamp.hpp"
+const char *service::detail::buildTimestamp = "@service_build_timestamp@";

--- a/service/buildtimestamp.cpp.in
+++ b/service/buildtimestamp.cpp.in
@@ -1,2 +1,2 @@
-#include "buildtimestamp.hpp"
+#include "service/buildtimestamp.hpp"
 const char *service::detail::buildTimestamp = "@service_build_timestamp@";

--- a/service/buildtimestamp.hpp
+++ b/service/buildtimestamp.hpp
@@ -3,7 +3,7 @@
 
 namespace service { namespace detail {
 
-const char *buildTimestamp;
+extern const char *buildTimestamp;
 
 } } // namespace service::detail
 

--- a/service/buildtimestamp.hpp
+++ b/service/buildtimestamp.hpp
@@ -3,7 +3,7 @@
 
 namespace service { namespace detail {
 
-const char *buildTimestamp = "@build_timestamp@";
+const char *buildTimestamp;
 
 } } // namespace service::detail
 

--- a/service/githash.cpp.in
+++ b/service/githash.cpp.in
@@ -1,0 +1,2 @@
+#include "githash.hpp"
+const char *service::detail::gitHash = "@service_git_hash@";

--- a/service/githash.cpp.in
+++ b/service/githash.cpp.in
@@ -1,2 +1,2 @@
-#include "githash.hpp"
+#include "service/githash.hpp"
 const char *service::detail::gitHash = "@service_git_hash@";

--- a/service/githash.hpp
+++ b/service/githash.hpp
@@ -3,7 +3,7 @@
 
 namespace service { namespace detail {
 
-const char *gitHash = "@git_hash@";
+const char *gitHash;
 
 } } // namespace service::detail
 

--- a/service/githash.hpp
+++ b/service/githash.hpp
@@ -3,7 +3,7 @@
 
 namespace service { namespace detail {
 
-const char *gitHash;
+extern const char *gitHash;
 
 } } // namespace service::detail
 


### PR DESCRIPTION
- Fixes typo, that caused empty timestamp in versionInfo :see_no_evil:.
- Minimizes recompilation by generating only small cpp files with timestamp and git hash.